### PR TITLE
Mieubrisse/tighten fully connected test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Upgrade controller Docker image to allow for a Docker network per test
 * Run tests in parallel!
 * Removed references to `fiveNode` in testsuite (because these networks are no longer five-node, and the network size is less important than whether it's staking or not)
+* Make the fully-connected-node test actually test staker registration by ensuring a second node sees the newly-registered-as-staker node
 
 # 0.3.1
 * Specify --http-host CLI flag in GetStartCommand to have RPC calls bind to publicIP


### PR DESCRIPTION
NOTE: Review after https://github.com/kurtosis-tech/ava-e2e-tests/pull/66 !!!

NOTE: This test isn't passing, but given my understanding of how stakers work I think it should be - I want to discuss with you (either here or on Slack) why.

Namely:
```
after we run GetFundsAndStartValidating, do we expect a node to be equivalent to the bootstrappers in that, it has peers == all the other nodes on the network? I'm making the fully-connected test actually test the thing it's supposed to by:
1) spinning up 5 boot nodes (normal)
2) adding two non-boot nodes
3) calling GetFundsAndStartValidating from the highlevel API
4) verifying that the node who became a validator has all 6 other nodes in the network (just like the boot node).
However, this isn't happening - that first node who becomes a validator is still only having the 5 boot nodes in his peer list. This is wrong, correct?
```