### PR TITLE
delegator node id should come from delegator client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Drop default loglevel for initializer & controller down to DEBUG
 * Upgrade controller Docker image to allow for a Docker network per test
 * Run tests in parallel!
+* Fix bug in RPC workflow test where delegator ID was actually staker ID
 
 # 0.3.1
 * Specify --http-host CLI flag in GetStartCommand to have RPC calls bind to publicIP

--- a/commons/ava_testsuite/staking_gecko_network_tests.go
+++ b/commons/ava_testsuite/staking_gecko_network_tests.go
@@ -49,7 +49,7 @@ func (test StakingNetworkRpcWorkflowTest) Run(network interface{}, context tests
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err, "Could not get staker node ID."))
 	}
-	delegatorNodeId, err := stakerClient.InfoApi().GetNodeId()
+	delegatorNodeId, err := delegatorClient.InfoApi().GetNodeId()
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err, "Could not get delegator node ID."))
 	}


### PR DESCRIPTION
found a typo in the workflow test, quick fix