### PR TITLE
Gmarchetti/clarify high level gecko client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Significantly up test execution timeouts
 * Make controller Docker image `tee` to the logfile, rather than redirecting all output
 * Implement a 10-second HTTP request timeout in the Gecko client
+* Rename HighLevelGeckoClient to RpcWorkflowRunner and move to ava_testsuite package
 
 # 0.6.0
 * Use Kurtosis version that allows the user to configure network width

--- a/commons/ava_testsuite/fully_connected_test/fully_connected_test_.go
+++ b/commons/ava_testsuite/fully_connected_test/fully_connected_test_.go
@@ -3,6 +3,7 @@ package fully_connected_test
 import (
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_networks"
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_services"
+	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_testsuite/rpc_workflow_runner"
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_testsuite/verifier"
 	"github.com/kurtosis-tech/ava-e2e-tests/gecko_client"
 	"github.com/kurtosis-tech/kurtosis/commons/networks"
@@ -48,7 +49,7 @@ func (test StakingNetworkFullyConnectedTest) Run(network networks.Network, conte
 	}
 
 	nonBootValidatorClient := allGeckoClients[nonBootValidatorServiceId]
-	highLevelExtraStakerClient := ava_networks.NewHighLevelGeckoClient(
+	highLevelExtraStakerClient := rpc_workflow_runner.NewRpcWorkflowRunner(
 		nonBootValidatorClient,
 		stakerUsername,
 		stakerPassword,

--- a/commons/ava_testsuite/rpc_workflow_runner/rpc_workflow_runner.go
+++ b/commons/ava_testsuite/rpc_workflow_runner/rpc_workflow_runner.go
@@ -1,6 +1,7 @@
-package ava_networks
+package rpc_workflow_runner
 
 import (
+	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_networks"
 	"github.com/kurtosis-tech/ava-e2e-tests/gecko_client"
 	"github.com/palantir/stacktrace"
 	"github.com/sirupsen/logrus"
@@ -24,11 +25,11 @@ const (
 	IMPORT_AVA_TO_XCHAIN_TIMEOUT = time.Second
 )
 
-type HighLevelGeckoClient struct {
+type RpcWorkflowRunner struct {
 	client                   *gecko_client.GeckoClient
 	geckoUser                *GeckoUser
 	/*
-		This timeout represents the time the HighLevelGeckoClient will wait for some state
+		This timeout represents the time the RpcWorkflowRunner will wait for some state
 		change in the network to be understood as accepted and implemented by the underlying
 		Gecko client (XChain transaction acceptance, Ava transfer to PChain, etc). There is
 		only one timeout for each kind of state change in order to reduce the complexity of
@@ -40,12 +41,12 @@ type HighLevelGeckoClient struct {
 	networkAcceptanceTimeout time.Duration
 }
 
-func NewHighLevelGeckoClient(
+func NewRpcWorkflowRunner(
 		client *gecko_client.GeckoClient,
 		username string,
 		password string,
-		networkAcceptanceTimeout time.Duration) *HighLevelGeckoClient {
-	return &HighLevelGeckoClient{
+		networkAcceptanceTimeout time.Duration) *RpcWorkflowRunner {
+	return &RpcWorkflowRunner{
 		client:                   client,
 		geckoUser:                NewGeckoUser(username, password),
 		networkAcceptanceTimeout: networkAcceptanceTimeout,
@@ -65,41 +66,41 @@ func NewGeckoUser(username string, password string) *GeckoUser {
 	High level function that takes a regular node with no Ava and funds it from genesis,
 	transfers those funds to the PChain, and registers it as a validator on the default subnet.
  */
-func (highLevelGeckoClient HighLevelGeckoClient) GetFundsAndStartValidating(
+func (runner RpcWorkflowRunner) GetFundsAndStartValidating(
 	    seedAmount int64,
 	    stakeAmount int64) error {
-	client := highLevelGeckoClient.client
+	client := runner.client
 	stakerNodeId, err := client.InfoApi().GetNodeId()
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not get staker node ID.")
 	}
-	_, err = highLevelGeckoClient.CreateAndSeedXChainAccountFromGenesis(seedAmount)
+	_, err = runner.CreateAndSeedXChainAccountFromGenesis(seedAmount)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not seed XChain account from Genesis.")
 	}
-	stakerPchainAddress, err := highLevelGeckoClient.TransferAvaXChainToPChain(seedAmount)
+	stakerPchainAddress, err := runner.TransferAvaXChainToPChain(seedAmount)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not transfer AVA from XChain to PChain account information")
 	}
-	_, err = highLevelGeckoClient.CreateAndSeedXChainAccountFromGenesis(seedAmount)
+	_, err = runner.CreateAndSeedXChainAccountFromGenesis(seedAmount)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not seed XChain account from Genesis.")
 	}
 	// Adding staker
-	err = highLevelGeckoClient.AddValidatorOnSubnet(stakerNodeId, stakerPchainAddress, stakeAmount)
+	err = runner.AddValidatorOnSubnet(stakerNodeId, stakerPchainAddress, stakeAmount)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not add staker %s to default subnet.", stakerNodeId)
 	}
 	return nil
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) AddDelegatorOnSubnet(
+func (runner RpcWorkflowRunner) AddDelegatorOnSubnet(
 		delegateeNodeId string,
 		pchainAddress string,
 		stakeAmount int64,
 		) error {
-	client := highLevelGeckoClient.client
-	currentPayerNonce, err := highLevelGeckoClient.getCurrentPayerNonce(pchainAddress)
+	client := runner.client
+	currentPayerNonce, err := runner.getCurrentPayerNonce(pchainAddress)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to get payer nonce from address %s", pchainAddress)
 	}
@@ -117,8 +118,8 @@ func (highLevelGeckoClient HighLevelGeckoClient) AddDelegatorOnSubnet(
 	addDelegatorSignedTxn, err := client.PChainApi().Sign(
 		addDelegatorUnsignedTxn,
 		pchainAddress,
-		highLevelGeckoClient.geckoUser.username,
-		highLevelGeckoClient.geckoUser.password)
+		runner.geckoUser.username,
+		runner.geckoUser.password)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to sign delegator transaction.")
 	}
@@ -132,12 +133,12 @@ func (highLevelGeckoClient HighLevelGeckoClient) AddDelegatorOnSubnet(
 	return nil
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) AddValidatorOnSubnet(
+func (runner RpcWorkflowRunner) AddValidatorOnSubnet(
 		nodeId string,
 		pchainAddress string,
 		stakeAmount int64) error {
-	client := highLevelGeckoClient.client
-	currentPayerNonce, err := highLevelGeckoClient.getCurrentPayerNonce(pchainAddress)
+	client := runner.client
+	currentPayerNonce, err := runner.getCurrentPayerNonce(pchainAddress)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to get payer nonce from address %s", pchainAddress)
 	}
@@ -156,8 +157,8 @@ func (highLevelGeckoClient HighLevelGeckoClient) AddValidatorOnSubnet(
 	addStakerSignedTxn, err := client.PChainApi().Sign(
 		addStakerUnsignedTxn,
 		pchainAddress,
-		highLevelGeckoClient.geckoUser.username,
-		highLevelGeckoClient.geckoUser.password)
+		runner.geckoUser.username,
+		runner.geckoUser.password)
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to sign staker transaction.")
 	}
@@ -168,7 +169,7 @@ func (highLevelGeckoClient HighLevelGeckoClient) AddValidatorOnSubnet(
 	for time.Now().Unix() < stakingStartTime {
 		time.Sleep(time.Second)
 	}
-	highLevelGeckoClient.waitForValidatorAddition(nodeId, nil)
+	runner.waitForValidatorAddition(nodeId, nil)
 	return nil
 }
 
@@ -178,11 +179,11 @@ func (highLevelGeckoClient HighLevelGeckoClient) AddValidatorOnSubnet(
 	Transfers funds from the genesis account to the new XChain account using the Genesis private key.
 	Returns the new, funded XChain account address.
  */
-func (highLevelGeckoClient HighLevelGeckoClient) CreateAndSeedXChainAccountFromGenesis(
+func (runner RpcWorkflowRunner) CreateAndSeedXChainAccountFromGenesis(
 		amount int64) (string, error) {
-	client := highLevelGeckoClient.client
-	username := highLevelGeckoClient.geckoUser.username
-	password := highLevelGeckoClient.geckoUser.password
+	client := runner.client
+	username := runner.geckoUser.username
+	password := runner.geckoUser.password
 	_, err := client.KeystoreApi().CreateUser(username, password)
 	if err != nil {
 		stacktrace.Propagate(err, "Could not create user.")
@@ -198,7 +199,7 @@ func (highLevelGeckoClient HighLevelGeckoClient) CreateAndSeedXChainAccountFromG
 	genesisAccountAddress, err := client.XChainApi().ImportKey(
 		GENESIS_USERNAME,
 		GENESIS_PASSWORD,
-		DefaultLocalNetGenesisConfig.FundedAddresses.PrivateKey)
+		ava_networks.DefaultLocalNetGenesisConfig.FundedAddresses.PrivateKey)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to take control of genesis account.")
 	}
@@ -213,7 +214,7 @@ func (highLevelGeckoClient HighLevelGeckoClient) CreateAndSeedXChainAccountFromG
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to send AVA to test account address %s", testAccountAddress)
 	}
-	err = highLevelGeckoClient.waitForXchainTransactionAcceptance(txnId)
+	err = runner.waitForXchainTransactionAcceptance(txnId)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to wait for transaction acceptance.")
 	}
@@ -225,11 +226,11 @@ func (highLevelGeckoClient HighLevelGeckoClient) CreateAndSeedXChainAccountFromG
 	Transfers funds from an XChain account owned by that username and password to the new PChain account.
 	Returns the new, funded PChain account address.
 */
-func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaXChainToPChain(
+func (runner RpcWorkflowRunner) TransferAvaXChainToPChain(
 		amount int64) (string, error) {
-	client := highLevelGeckoClient.client
-	username := highLevelGeckoClient.geckoUser.username
-	password := highLevelGeckoClient.geckoUser.password
+	client := runner.client
+	username := runner.geckoUser.username
+	password := runner.geckoUser.password
 	pchainAddress, err := client.PChainApi().CreateAccount(username, password, nil)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to create new account on PChain")
@@ -238,11 +239,11 @@ func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaXChainToPChain(
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to export AVA to pchainAddress %s", pchainAddress)
 	}
-	err = highLevelGeckoClient.waitForXchainTransactionAcceptance(txnId)
+	err = runner.waitForXchainTransactionAcceptance(txnId)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "")
 	}
-	currentPayerNonce, err := highLevelGeckoClient.getCurrentPayerNonce(pchainAddress)
+	currentPayerNonce, err := runner.getCurrentPayerNonce(pchainAddress)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to get payer nonce from address %s", pchainAddress)
 	}
@@ -254,7 +255,7 @@ func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaXChainToPChain(
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to issue importAVA transaction.")
 	}
-	highLevelGeckoClient.waitForPchainNonZeroBalance(pchainAddress)
+	runner.waitForPchainNonZeroBalance(pchainAddress)
 	return pchainAddress, nil
 }
 
@@ -262,16 +263,16 @@ func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaXChainToPChain(
 	Transfers funds from a Phain account owned by that username and password to an XChain account.
 	Returns the XChain account address.
 */
-func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaPChainToXChain(
-	// HighLevelGeckoClient must own both pchainAddress and xchainAddress.
+func (runner RpcWorkflowRunner) TransferAvaPChainToXChain(
+	// RpcWorkflowRunner must own both pchainAddress and xchainAddress.
 		pchainAddress string,
 		xchainAddress string,
 		amount int64) (string, error) {
-	client := highLevelGeckoClient.client
-	username := highLevelGeckoClient.geckoUser.username
-	password := highLevelGeckoClient.geckoUser.password
+	client := runner.client
+	username := runner.geckoUser.username
+	password := runner.geckoUser.password
 	xchainAddressWithoutPrefix := strings.TrimPrefix(xchainAddress, XCHAIN_ADDRESS_PREFIX)
-	currentPayerNonce, err := highLevelGeckoClient.getCurrentPayerNonce(pchainAddress)
+	currentPayerNonce, err := runner.getCurrentPayerNonce(pchainAddress)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to get current payer nonce from pchainAddress %v", pchainAddress)
 	}
@@ -304,21 +305,21 @@ func (highLevelGeckoClient HighLevelGeckoClient) TransferAvaPChainToXChain(
 			return "", stacktrace.Propagate(err, "Failed import AVA to xchainAddress %s", xchainAddress)
 		}
 	}
-	err = highLevelGeckoClient.waitForXchainTransactionAcceptance(txnId)
+	err = runner.waitForXchainTransactionAcceptance(txnId)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "Failed to wait for acceptance of transaction on XChain.")
 	}
 	return xchainAddress, nil
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) waitForXchainTransactionAcceptance(txnId string) error {
-	client := highLevelGeckoClient.client
+func (runner RpcWorkflowRunner) waitForXchainTransactionAcceptance(txnId string) error {
+	client := runner.client
 	status, err := client.XChainApi().GetTxStatus(txnId)
 	if err != nil {
 		return stacktrace.Propagate(err,"Failed to get status.")
 	}
 	pollStartTime := time.Now()
-	for i := 0; time.Since(pollStartTime) < highLevelGeckoClient.networkAcceptanceTimeout && status != TRANSACTION_ACCEPTED_STATUS; i++ {
+	for i := 0; time.Since(pollStartTime) < runner.networkAcceptanceTimeout && status != TRANSACTION_ACCEPTED_STATUS; i++ {
 		status, err = client.XChainApi().GetTxStatus(txnId)
 		if err != nil {
 			return stacktrace.Propagate(err,"Failed to get status.")
@@ -333,14 +334,14 @@ func (highLevelGeckoClient HighLevelGeckoClient) waitForXchainTransactionAccepta
 	}
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) waitForValidatorAddition(nodeId string, subnetIdPtr *string) error {
-	client := highLevelGeckoClient.client
+func (runner RpcWorkflowRunner) waitForValidatorAddition(nodeId string, subnetIdPtr *string) error {
+	client := runner.client
 	validators, err := client.PChainApi().GetCurrentValidators(subnetIdPtr)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not get current validators")
 	}
 	pollStartTime := time.Now()
-	for i := 0; time.Since(pollStartTime) < highLevelGeckoClient.networkAcceptanceTimeout && !checkValidatorInValidators(nodeId, validators); i++ {
+	for i := 0; time.Since(pollStartTime) < runner.networkAcceptanceTimeout && !checkValidatorInValidators(nodeId, validators); i++ {
 		time.Sleep(time.Second)
 		validators, err = client.PChainApi().GetCurrentValidators(subnetIdPtr)
 		if err != nil {
@@ -363,8 +364,8 @@ func checkValidatorInValidators(nodeId string, validators []gecko_client.Validat
 	return false
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) waitForPchainNonZeroBalance(pchainAddress string) error {
-	client := highLevelGeckoClient.client
+func (runner RpcWorkflowRunner) waitForPchainNonZeroBalance(pchainAddress string) error {
+	client := runner.client
 	pchainAccount, err := client.PChainApi().GetAccount(pchainAddress)
 	if err != nil {
 		return stacktrace.Propagate(err, "Could not get PChain account information")
@@ -374,7 +375,7 @@ func (highLevelGeckoClient HighLevelGeckoClient) waitForPchainNonZeroBalance(pch
 		return stacktrace.Propagate(err,"Failed to get balance.")
 	}
 	pollStartTime := time.Now()
-	for i := 0; time.Since(pollStartTime) < highLevelGeckoClient.networkAcceptanceTimeout && balance == "0"; i++ {
+	for i := 0; time.Since(pollStartTime) < runner.networkAcceptanceTimeout && balance == "0"; i++ {
 		pchainAccount, err = client.PChainApi().GetAccount(pchainAddress)
 		if err != nil {
 			return stacktrace.Propagate(err,"Failed to get account information.")
@@ -390,8 +391,8 @@ func (highLevelGeckoClient HighLevelGeckoClient) waitForPchainNonZeroBalance(pch
 	}
 }
 
-func (highLevelGeckoClient HighLevelGeckoClient) getCurrentPayerNonce(pchainAddress string) (int, error) {
-	pchainAccountInfo, err := highLevelGeckoClient.client.PChainApi().GetAccount(pchainAddress)
+func (runner RpcWorkflowRunner) getCurrentPayerNonce(pchainAddress string) (int, error) {
+	pchainAccountInfo, err := runner.client.PChainApi().GetAccount(pchainAddress)
 	if err != nil {
 		return 0, stacktrace.Propagate(err, "Failed to get pchain account info.")
 	}

--- a/commons/ava_testsuite/rpc_workflow_runner/rpc_workflow_runner.go
+++ b/commons/ava_testsuite/rpc_workflow_runner/rpc_workflow_runner.go
@@ -25,6 +25,12 @@ const (
 	IMPORT_AVA_TO_XCHAIN_TIMEOUT = time.Second
 )
 
+/*
+	RpcWorkflowRunner executes standard testing workflows like funding accounts from
+	genesis and adding nodes as validators, using the a given gecko client handle as the
+	entry point to the test network. It runs the RpcWorkflows using the credential
+	set in the GeckoUser field.
+ */
 type RpcWorkflowRunner struct {
 	client                   *gecko_client.GeckoClient
 	geckoUser                *GeckoUser

--- a/commons/ava_testsuite/rpc_workflow_test/rpc_workflow_test_.go
+++ b/commons/ava_testsuite/rpc_workflow_test/rpc_workflow_test_.go
@@ -3,6 +3,7 @@ package rpc_workflow_test
 import (
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_networks"
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_services"
+	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_testsuite/rpc_workflow_runner"
 	"github.com/kurtosis-tech/kurtosis/commons/networks"
 	"github.com/kurtosis-tech/kurtosis/commons/testsuite"
 	"github.com/palantir/stacktrace"
@@ -51,12 +52,12 @@ func (test StakingNetworkRpcWorkflowTest) Run(network networks.Network, context 
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err, "Could not get delegator node ID."))
 	}
-	highLevelStakerClient := ava_networks.NewHighLevelGeckoClient(
+	highLevelStakerClient := rpc_workflow_runner.NewRpcWorkflowRunner(
 		stakerClient,
 		stakerUsername,
 		stakerPassword,
 		networkAcceptanceTimeout)
-	highLevelDelegatorClient := ava_networks.NewHighLevelGeckoClient(
+	highLevelDelegatorClient := rpc_workflow_runner.NewRpcWorkflowRunner(
 		delegatorClient,
 		delegatorUsername,
 		delegatorPassword,
@@ -105,7 +106,7 @@ func (test StakingNetworkRpcWorkflowTest) Run(network networks.Network, context 
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err, "Failed to transfer Ava from PChain to XChain."))
 	}
-	xchainAccountInfo, err := stakerClient.XChainApi().GetBalance(stakerXchainAddress, ava_networks.AVA_ASSET_ID)
+	xchainAccountInfo, err := stakerClient.XChainApi().GetBalance(stakerXchainAddress, rpc_workflow_runner.AVA_ASSET_ID)
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err, "Failed to get account info for account %v.", stakerXchainAddress))
 	}

--- a/commons/ava_testsuite/unrequested_chit_spammer_test/unrequested_chit_spammer_test_.go
+++ b/commons/ava_testsuite/unrequested_chit_spammer_test/unrequested_chit_spammer_test_.go
@@ -3,6 +3,7 @@ package unrequested_chit_spammer_test
 import (
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_networks"
 	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_services"
+	"github.com/kurtosis-tech/ava-e2e-tests/commons/ava_testsuite/rpc_workflow_runner"
 	"github.com/kurtosis-tech/kurtosis/commons/networks"
 	"github.com/kurtosis-tech/kurtosis/commons/testsuite"
 	"github.com/palantir/stacktrace"
@@ -37,7 +38,7 @@ func (test StakingNetworkUnrequestedChitSpammerTest) Run(network networks.Networ
 		if err != nil {
 			context.Fatal(stacktrace.Propagate(err, "Failed to get byzantine client."))
 		}
-		highLevelByzClient := ava_networks.NewHighLevelGeckoClient(
+		highLevelByzClient := rpc_workflow_runner.NewRpcWorkflowRunner(
 			byzClient,
 			byzantineUsername,
 			byzantinePassword,
@@ -63,7 +64,7 @@ func (test StakingNetworkUnrequestedChitSpammerTest) Run(network networks.Networ
 	if err != nil {
 		context.Fatal(stacktrace.Propagate(err,"Failed to get staker client."))
 	}
-	highLevelNormalClient := ava_networks.NewHighLevelGeckoClient(
+	highLevelNormalClient := rpc_workflow_runner.NewRpcWorkflowRunner(
 		normalClient,
 		stakerUsername,
 		stakerPassword,


### PR DESCRIPTION
Renaming high level gecko client to RPC Workflow Runner and moving it to the ava_testsuite package